### PR TITLE
Use HTTP-URL for modules so we can access behind a proxy

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "djangotasks"]
 	path = djangotasks
-	url = git@github.com:Piratenfraktion-Berlin/djangotasks.git
+	url = https://github.com/Piratenfraktion-Berlin/djangotasks.git
 [submodule "videoportal/pytranscode"]
 	path = videoportal/pytranscode
-	url = git@github.com:Piratenfraktion-Berlin/pytranscode.git
+	url = https://github.com/Piratenfraktion-Berlin/pytranscode.git


### PR DESCRIPTION
The gIt protocol is not accessible behind HTTP proxies and we only need read support for checking out the submodules.
